### PR TITLE
Better shebang fix

### DIFF
--- a/scripts/notify-send.py
+++ b/scripts/notify-send.py
@@ -1,4 +1,4 @@
-#!/bin/python3
+#!/usr/bin/env python3
 
 import notify2
 import argparse


### PR DESCRIPTION
The previous shebang was explicitly loading python from `/bin/python3` but the executable can be anywhere. As an example, on my system (Ubuntu 18.04), the executable is found on `/usr/bin/python3`