### PR TITLE
Enable colon characters in action names

### DIFF
--- a/notify_send_py/notify_send_py.py
+++ b/notify_send_py/notify_send_py.py
@@ -116,7 +116,7 @@ class NotifySendPy:
         if actions:
             n.connect("closed", self.close)
             for action in actions:
-                [key, value] = action.split(':')
+                [key, value] = action.split(':', maxsplit=1)
                 n.add_action(key, value, self.action)
 
         if replaces_process:


### PR DESCRIPTION
Trying to use an action with a colon in it (like a URL with the protocol intact) would cause an error due to split only expecting two results. By adding `maxsplit=1`, after the first colon, which is used to delimit the key and name, everything else is kept intact in the name. For example, this now works:

```sh
notify-send.py --action default:https://google.com -- "google it"
```

![image](https://user-images.githubusercontent.com/1944082/117765985-d2084680-b269-11eb-8c1d-3e33c426297e.png)
